### PR TITLE
빌드에러 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 android {
     namespace = "com.example.running_app"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "com.example.running_app"


### PR DESCRIPTION
Dependency 'androidx.activity:activity:1.8.0' requires libraries and applications that
depend on it to compile against version 34 or later of the Android APIs.
:app is currently compiled against android-33.

complieSdk를 33설정시 위와같은 빌드에러로 인해 34로 수정하였습니다.

참고 : https://github.com/android/ndk/issues/1955