### PR TITLE
compileSdk 버전으로 인한 빌드에러 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 android {
     namespace = "com.example.running_app"
-    compileSdk = 34
+    compileSdk = 33
 
     defaultConfig {
         applicationId = "com.example.running_app"
@@ -42,7 +42,7 @@ android {
 dependencies {
 
     implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("com.google.android.material:material:1.10.0")
+    implementation("com.google.android.material:material:1.9.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")


### PR DESCRIPTION
기존 세팅된 "com.google.android.material:material:1.10.0" 버전이 compileSdk 34버전을 필요로 함에 따라 생긴 빌드에러 이슈임을 확인했습니다.
따라서 compileSdk 버전을 수정하지 않고 material:1.10.0 버전을 material:1.9.0으로 수정하는 방향으로 이슈를 해결했습니다.

참고 : https://github.com/material-components/material-components-android/releases/tag/1.10.0-alpha01
